### PR TITLE
Support using scanpath instead of hardcoded target/classes. Worked on…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>de.viadee</groupId>
     <artifactId>viadeeProcessApplicationValidator</artifactId>
 
-    <version>3.0.6</version>
+    <version>3.0.7-SNAPSHOT</version>
 
     <name>viadee Process Application Validator</name>
 
@@ -413,7 +413,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
+            <!--<plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
                 <version>5.3.2</version>
@@ -431,7 +431,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
+            </plugin>-->
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>

--- a/src/main/java/de/viadee/bpm/vPAV/FileScanner.java
+++ b/src/main/java/de/viadee/bpm/vPAV/FileScanner.java
@@ -197,12 +197,7 @@ public class FileScanner {
 
 		try {
 			URL urlTargetClass;
-			if (RuntimeConfig.getInstance().isTest()) {
-				urlTargetClass = Paths.get("target/test-classes").toUri().toURL();
-			} else {
-				urlTargetClass = Paths.get("target/classes").toUri().toURL();
-			}
-
+			urlTargetClass = Paths.get(RuntimeConfig.getInstance().getScanPath()).toUri().toURL();
 			String path = urlTargetClass.toString();
 			addStringToSootPath(path);
 		} catch (MalformedURLException e) {
@@ -224,8 +219,9 @@ public class FileScanner {
 				}
 			}
 			// retrieve all jars during runtime and pass them to get class files
-			if (Pattern.compile(".*target/classes.*").matcher(entry).find()
-					|| Pattern.compile(".*target/test-classes.*").matcher(entry).find()) {
+			String osClassPath = RuntimeConfig.getInstance().getScanPath().replaceAll("\\\\", "/");
+			String entryPath = entry.replaceAll("\\\\", "/");
+            if (Pattern.compile(".*" + osClassPath + ".*").matcher(entryPath).find()) {
 				addStringToSootPath(entry);
 			}
 


### PR DESCRIPTION
Together with 
`scanpath=build/classes/`
in vPav.properties file, this allow to work on gradle projects.